### PR TITLE
Rely on `UDP::openConnection` to validate address and port

### DIFF
--- a/IO.cpp
+++ b/IO.cpp
@@ -70,7 +70,7 @@ namespace IO
 
 		if(code != 0 || address == NULL)
 		{
-			throw "Failed to resolve remote socket address for UDP connection.";
+			throw "UDP network address and/or port not valid.";
 			return;
 		}
 

--- a/Main.cpp
+++ b/Main.cpp
@@ -34,13 +34,13 @@ SOFTWARE.
 MessageHub<SystemMessage> SystemMessages;
 
 #ifdef WIN32
-BOOL WINAPI consoleHandler(DWORD signal) 
+BOOL WINAPI consoleHandler(DWORD signal)
 {
 	if (signal == CTRL_C_EVENT) SystemMessages.Send(SystemMessage::Stop);
 	return TRUE;
 }
 #else
-void consoleHandler(int signal) 
+void consoleHandler(int signal)
 {
 	SystemMessages.Send(SystemMessage::Stop);
 }
@@ -88,27 +88,6 @@ int getNumber(std::string str, int min, int max)
 	return number;
 }
 
-bool checkNetworkAddress(std::string s)
-{
-	bool correct = true;
-	int count = 0;
-
-	char str[20];
-	int len = s.copy(str, 20);  str[len] = '\0';
-
-	char* token = strtok(str, ".");
-
-	while (token)
-	{
-		correct &= getNumber(std::string(token),0,255)>=0;
-		token = strtok(NULL, ".");
-		count++;
-	}
-
-	if (correct && count == 4) return true;
-	return false;
-}
-
 void Usage()
 {
 	std::cerr << "use: AIS-catcher [options]" << std::endl;
@@ -117,7 +96,7 @@ void Usage()
 	std::cerr << "\t[-s xxx sample rate in Hz (default: based on SDR device)]" << std::endl;
 	std::cerr << "\t[-v [option: xx] enable verbose mode, optional to provide update frequency in seconds (default: false)]" << std::endl;
 	std::cerr << "\t[-q surpress NMEA messages to screen (default: false)]" << std::endl;
-	std::cerr << "\t[-u xx.xx.xx.xx yyy UDP address and port (default: off)]" << std::endl;
+	std::cerr << "\t[-u address port - UDP address and port (default: off)]" << std::endl;
 	std::cerr << std::endl;
 	std::cerr << "\t[-r filename - read IQ data from raw \'unsigned char\' file]" << std::endl;
 	std::cerr << "\t[-r cu8 filename - read IQ data from raw \'unsigned char\' file]" << std::endl;
@@ -347,12 +326,6 @@ int main(int argc, char* argv[])
 				break;
 			case 'u':
 				udp_address = arg1; udp_port = arg2;
-
-				if(!checkNetworkAddress(udp_address) || getNumber(udp_port,0,65535)<0)
-				{
-					std::cerr << "UDP network address and/or port not valid." << std::endl;
-					return -1;
-				}
 				ptr += 2;
 				break;
 			case 'h':
@@ -436,7 +409,7 @@ int main(int argc, char* argv[])
 		case Device::Type::RTLSDR:
 		{
 #ifdef HASRTLSDR
- 
+
 			Device::RTLSDR* device = new Device::RTLSDR();
 			device->openDevice(handle);
 
@@ -492,7 +465,7 @@ int main(int argc, char* argv[])
 			liveModels[0]->Output() >> udp;
 		}
 
-		if (NMEA_to_screen) 
+		if (NMEA_to_screen)
 			liveModels[0]->Output() >> nmea_screen;
 
 		// Set up Device

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # AIS-catcher - An AIS receiver for RTL-SDR dongles and Airspy HF+
-This package will add the ```AIS-catcher``` command - a dual channel AIS receiver for RTL-SDR dongles and the Airspy HF+. Output is send in the form of NMEA messages to either screen or broadcasted over UDP. The idea behind ```AIS-catcher``` is that it should be easy to run various decoding model in parallel and read input from file to create an environment to test and benchmark different decoding models in a live setting. The program provides the option to read and decode the raw discriminator output of a VHF receiver as well. 
+This package will add the ```AIS-catcher``` command - a dual channel AIS receiver for RTL-SDR dongles and the Airspy HF+. Output is send in the form of NMEA messages to either screen or broadcasted over UDP. The idea behind ```AIS-catcher``` is that it should be easy to run various decoding model in parallel and read input from file to create an environment to test and benchmark different decoding models in a live setting. The program provides the option to read and decode the raw discriminator output of a VHF receiver as well.
 
 ```AIS-catcher```  is created for research and educational purposes under the MIT license. It is a hobby project from an unqualified amateur and not tested and designed for reliability and correctness. You can play with the software but it is the user's responsibility to use it prudently. So, in summary, DO NOT rely upon this software in any way including for navigation and/or safety of life or property purposes.
 
@@ -21,7 +21,7 @@ use: AIS-catcher [options]
         [-s xxx sample rate in Hz (default: based on SDR device)]
         [-v [option: xx] enable verbose mode, optional to provide update frequency in seconds (default: false)]
         [-q surpress NMEA messages to screen (default: false)]
-        [-u xx.xx.xx.xx yyy UDP address and port (default: off)]
+        [-u address port - UDP address and port (default: off)]
 
         [-r filename - read IQ data from raw 'unsigned char' file]
         [-r cu8 filename - read IQ data from raw 'unsigned char' file]
@@ -74,26 +74,26 @@ To start AIS demodulation, print some occasional statistics (every 10 seconds) a
 ```console
 AIS-catcher -v 10 -u 127.0.0.1 12345
 ```
-If succesful, NMEA messages will start to come in, appear on the screen and send as UDP messages to `127.0.0.1` port `12345`. These console messages can be surpressed with the option ```-q```. 
+If succesful, NMEA messages will start to come in, appear on the screen and send as UDP messages to `127.0.0.1` port `12345`. These console messages can be surpressed with the option ```-q```.
 
 The following commands record a signal with ```rtl_sdr``` at a sampling rate of 288K Hz and then subsequently decodes the input with AIS-catcher:
 ```console
 rtl_sdr -s 288K -f 162M  test_288.raw
-AIS-catcher -r test_288.raw -s 288000 -v 
+AIS-catcher -r test_288.raw -s 288000 -v
 ```
 
 ## Multiple receiver models
 
 In the current version 4 different receiver models are embedded:
 
-- **Default model** (``-m 2``): the default demodulation engine 
+- **Default model** (``-m 2``): the default demodulation engine
 - **Base model (non-coherent)** (``-m 1``): similar to RTL-AIS (and GNUAIS/Aisdecoder) with some modifications to PLL and main receiver filter ([taken from here](https://jaspersnotebook.blogspot.com/2021/03/ais-vessel-tracking-designing.html)).
 - **Standard model (non-coherent)** (``-m 0``): as the base model with brute force timing recovery.
 - **FM discriminator model**: (``-m 3``) as  the 'standard' model but assumes input is output of a FM discriminator, hence no FM demodulation takes place which allows ```AIS-catcher``` to be used as GNUAIS and AISdecoder.
 
 The default model is the most time and memory consuming but experiments suggest it to be the most effective. In my home station it improves message count by a factor 2 - 3. The reception quality of the `standard` model over the `base` model is more modest at the expense of roughly a 20% increase in computation time. Advice is to start with the default model, which should run fine on most modern hardware including a Raspberry 4B and then scale down to ```-m 0```or even ```-m 1```, if needed.
 
-To get a sense of the performance of the different models, I have run a simple test in two different setups whereby ```AIS-catcher``` ran the main two models in parallel for 3 minutes and we counted the number of detected messages. 
+To get a sense of the performance of the different models, I have run a simple test in two different setups whereby ```AIS-catcher``` ran the main two models in parallel for 3 minutes and we counted the number of detected messages.
 
 Location: The Hague residential area with RTL-SDR v3 dongle and Shakespeare antenna with quite some (perhaps fair to say a lot of) blockage from surrounding buildings and antenna placed within a window, we have the following message count for various models and sample rates (over 3 minute run):
  | Model | Settings | Run 1 | Run 2 | Run 3 |
@@ -104,16 +104,16 @@ Location: The Hague residential area with RTL-SDR v3 dongle and Shakespeare ante
 | AIS-catcher v0.07 Standard (non-coherent) @ 288K |```-m 0 -s 288000``` |   47 | 49 | 35 |
 | AISRec 2.2 (trial)   | Sampling: very high, super fast| 132 | 140 | 121 |
 | rtl-ais v0.3  @ 1600K  | ```-n``` | 15 | 17  | 6 |
- 
-For completeness I performed seperate runs with [AISRec](https://sites.google.com/site/feverlaysoft/home) and [RTL-AIS](https://github.com/dgiardini/rtl-ais) as well. AISRec has some excellent sensitivity and is one of the most user friendly packages out there. It is highly recommended. RTL-AIS  is a very efficient and elegant open source AIS receiver with minimal hardware requirements and is a pioneer in the field of open source AIS software. 
 
-The first two rows are ran in parallel (i.e. on the same input signal) and therefore are comparable. Same for the two rows following. The other runs are provided for information purposes and cannot be compared as message density fluctuates over time and have different system and hardware requirements. Nevertheless, these non-scientifically conducted experiments suggest that 1) the Default model can perform better than the Standard model and 2) a higher sampling rate should be preferred over a lower rate where possible. 
+For completeness I performed seperate runs with [AISRec](https://sites.google.com/site/feverlaysoft/home) and [RTL-AIS](https://github.com/dgiardini/rtl-ais) as well. AISRec has some excellent sensitivity and is one of the most user friendly packages out there. It is highly recommended. RTL-AIS  is a very efficient and elegant open source AIS receiver with minimal hardware requirements and is a pioneer in the field of open source AIS software.
+
+The first two rows are ran in parallel (i.e. on the same input signal) and therefore are comparable. Same for the two rows following. The other runs are provided for information purposes and cannot be compared as message density fluctuates over time and have different system and hardware requirements. Nevertheless, these non-scientifically conducted experiments suggest that 1) the Default model can perform better than the Standard model and 2) a higher sampling rate should be preferred over a lower rate where possible.
 
 Finally some results with direct sight at the beach (Scheveningen) with a higher message density over 3 minutes (NESDR dongle with factory included antenna):
 | Model | 288K Ubuntu | 1536K Ubuntu |
-| :--- | :---: | :---: | 
+| :--- | :---: | :---: |
 | AIS-catcher v0.06 Default | 489 | 499|
-| AIS-catcher v0.06 Standard (non-coherent) | 417 | 439| 
+| AIS-catcher v0.06 Standard (non-coherent) | 417 | 439|
 | AIS-catcher v0.06 Base (non-coherent) | 408 | 429|
 
 The results for each column are comparable as based on the same input signal. Notice that with a better reception there is less of a difference between the different models and sampling rates.
@@ -136,17 +136,17 @@ The program will run and summarize the performance (count and timing) of three d
 [Standard (non-coherent)]	: 1.9e+02 ms
 [Base (non-coherent)]		: 1.7e+02 ms
 ```
-In this example the default model performs quite well in contrast to the standard non-coherent engine with 36 messages identified versus 3 for the standard engine. This is typical when there are few messages with poor quality. However, it  doubles the decoding time and has a higher memory usage (800 floats) so needs more powerful hardware. Please note that the improvements seen for this particular file are an exception. 
+In this example the default model performs quite well in contrast to the standard non-coherent engine with 36 messages identified versus 3 for the standard engine. This is typical when there are few messages with poor quality. However, it  doubles the decoding time and has a higher memory usage (800 floats) so needs more powerful hardware. Please note that the improvements seen for this particular file are an exception.
 
 ## Releases
 
-A release in binary format for Windows 32 bit (including required libraries) can obtained at request. Please note that you will have to install drivers using Zadig (https://www.rtl-sdr.com/tag/zadig/). After that, simply unpack the ZIP file in one directory and start the executable. For Linux systems, compilation instructions are below. 
+A release in binary format for Windows 32 bit (including required libraries) can obtained at request. Please note that you will have to install drivers using Zadig (https://www.rtl-sdr.com/tag/zadig/). After that, simply unpack the ZIP file in one directory and start the executable. For Linux systems, compilation instructions are below.
 
 ## Compilation process for Linux/Raspberry Pi
 
 Make sure you have the following dependencies:
   - librtlsdr and/or libairspyhf
- 
+
 The steps to compile AIS-catcher for RTL-SDR dongles are fairly straightforward on a Raspberry Pi 4B and Ubuntu systems. First ensure you have the necessary dependencies installed. If not, the following commands can be used:
 
 ```console
@@ -188,7 +188,7 @@ AIS-catcher -s 288000
 
 ## To do
 
-- Documenting and finetuning the default decoding model 
+- Documenting and finetuning the default decoding model
 - Ongoing: further improvements to reception and testing (e.g. improve coherent demodulation, filters, etc)
 - Performance improvements (align USB buffer size with multiple of 16K)
 - More testing: in particular in an area with high message density
@@ -197,4 +197,3 @@ AIS-catcher -s 288000
 - Windows driver improvements
 - ....
 - ....
-


### PR DESCRIPTION
This allows the use of the optional use of a hostname instead of IP address for the remote UDP host.

From some quick testing, this seems to identify invalid IP addresses (ie `260.1.2.3.`) and out or range port numbers (ie `70000`) to the same robustness as `checkNetworkAddress`.

My specific use case is with [kplex](http://www.stripydog.com/kplex/) in Docker containers where it is more convenient to refer to the other containers by name rather than IP.