### PR TITLE
Use the raw tag when publishing the container image

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -23,7 +23,7 @@ jobs:
           images: ghcr.io/${{ github.repository }}
           tags: |
             type=edge,branch=main
-            type=semver,pattern={{major}}.{{minor}}
+            type=ref,event=tag
 
       - name: Setup QEMU
         uses: docker/setup-qemu-action@v1


### PR DESCRIPTION
Apologies @jvde-github, please give this a try, I hope this will fix up the issues you were having with the container image not updating when publishing a new release.