### PR TITLE
build fixes for SoapySDR 0.7.2 (default on Debian stable)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -266,7 +266,7 @@ endif()
 if(SOAPYSDR)
 	pkg_check_modules(SOAPYSDR SoapySDR)
 
-	if(SOAPYSDR_INCLUDE_DIRS AND SOAPYSDR_LIBRARY_DIRS)
+	if(SOAPYSDR_FOUND)
 		message(STATUS "SOAPYSDR: found - ${SOAPYSDR_INCLUDE_DIRS}, ${SOAPYSDR_LIBRARIES}")
 		add_definitions(-DHASSOAPYSDR)
 	endif()

--- a/Device/SoapySDR.cpp
+++ b/Device/SoapySDR.cpp
@@ -188,7 +188,7 @@ namespace Device {
 				auto device = SoapySDR::Device::make(dev_str);
 				int nChannels = device->getNumChannels(SOAPY_SDR_RX);
 				for (int c = 0; c < nChannels; c++) {
-					std::string serial_str = "SCH" + std::to_string(c) + "-" + d["serial"];
+					std::string serial_str = "SCH" + std::to_string(c) + "-" + d["driver"];
 					int rate = device->getSampleRate(SOAPY_SDR_RX, c);
 					dev_list.push_back(SoapyDevice(dev_str, c, rate));
 					DeviceList.push_back(Description("SOAPYSDR", dev_str, serial_str, (uint64_t)cnt, Type::SOAPYSDR));

--- a/Device/SoapySDR.h
+++ b/Device/SoapySDR.h
@@ -20,7 +20,6 @@
 #include "Device.h"
 
 #ifdef HASSOAPYSDR
-#include <rtl-sdr.h>
 #include <SoapySDR/Version.hpp>
 #include <SoapySDR/Modules.hpp>
 #include <SoapySDR/Registry.hpp>


### PR DESCRIPTION
Hi, minor fixes that allow AIS-catcher to compile on my Debian stable (bullseye) with just out-of-the-box SoapySDR 0.7.2 device support (no other driver libraries installed).