### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ AIS-catcher -H http://aprs.fi/jsonais/post/secret-key ID callsign PROTOCOL aprs 
 ```
 Where ``secret-key`` should be your password and ``callsign`` your callsign.  The ``PROTOCOL`` setting instructs AIS-catcher to submit JSON in a form that is accepted by APRS.fi and posts a multi-part message. As another example, this functionality can feed the map of [Chaos Consulting](https://adsb.chaos-consulting.de/map/) without the need to install any additional scripts. The Chaos Consulting server has been set up so that it can read the AIS-catcher JSON format as per above:
 ```console
-AIS-catcher -H https://ais.chaos-consulting.de/shipin/index.php USERPWD "Station:Password" GZIP on INTERVAL 5
+AIS-catcher -H https://ais.chaos-consulting.de/shipin/index.php USERPWD Station:Password GZIP on INTERVAL 5
 ```
 Notice that this server requires authentication with a station name and password and accepts JSON with gzip encoding which significantly reduces bandwidth. The supported protocol switches are ``AISCATCHER`` (default), ``MINIMAL`` (NMEA lines and meta data), ``LINES`` (one JSON message per line), ``APRS`` (to submit to APRS.fi).
 


### PR DESCRIPTION
Removed quotes around Chaos Consulting credentials when using command line switch -H

The site throws a 401 unauthorized error if the credentials are in quotes. Removing the quotes solves the issue.