### PR TITLE
Re-add librtlsdr to Docker application image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN apt-get update
 RUN apt-get upgrade -y
 
 RUN apt-get install git make gcc g++ cmake pkg-config libusb-1.0-0-dev -y
-RUN apt-get install libusb-1.0 libairspy0 libhackrf0 libairspyhf1 libzmq5 libsoxr0 libpq5 libz1 libssl3 -y
+RUN apt-get install libusb-1.0 librtlsdr0 libairspy0 libhackrf0 libairspyhf1 libzmq5 libsoxr0 libpq5 libz1 libssl3 -y
 
 RUN cd /root; git clone https://github.com/osmocom/rtl-sdr.git
 RUN cd /root/rtl-sdr; mkdir build; cd build; cmake ../ -DCMAKE_BUILD_TYPE=Release -DINSTALL_UDEV_RULES=ON -DDETACH_KERNEL_DRIVER=ON; make; make install;


### PR DESCRIPTION
Hi @jvde-github,

thanks for creating and maintaining this great application! I am happily running it on a Raspberry Pi with a RTL-SDR dongle :smile: 

This PR partly reverts commit 1a3fd0faa4dd3432ba0bfa09795c713f0b21b74e, where `librtlsdr` was removed from the application container.