### PR TITLE
Added processing of FREQOFFSET argument, previously being ignored for RTLTCP.

### DIFF
--- a/Device/RTLTCP.cpp
+++ b/Device/RTLTCP.cpp
@@ -175,6 +175,9 @@ namespace Device {
 		else if (option == "RTLAGC") {
 			RTL_AGC = Util::Parse::Switch(arg);
 		}
+		else if (option == "FREQOFFSET") {
+			freq_offset = Util::Parse::Integer(arg, -150, 150);
+		}
 		else if (option == "PERSIST") {
 			persistent = Util::Parse::Switch(arg);
 		}


### PR DESCRIPTION
Identified that after switching from RTLSDR to RTLTCP that the PPM/FREQOFFSET argument value was not being used, so application was passing the initialised value of 0 through to "rtl_tcp" server.

I've confirmed that setting FREQOFFSET via "-gr" and or the -p argument works and when both supplied "-p" is process last.
