### PR TITLE
Add Eniro charts as map type

### DIFF
--- a/HTML/script.js
+++ b/HTML/script.js
@@ -6598,6 +6598,22 @@ addTileLayer("Satellite", new ol.layer.Tile({
     })
 }));
 
+addTileLayer("Eniro (Scandinavia)", new ol.layer.Tile({
+    source: new ol.source.XYZ({
+        tileUrlFunction: function (tileCoord) {
+            const z = tileCoord[0];
+            const x = tileCoord[1];
+            const y = Math.pow(2, z) - tileCoord[2] - 1;
+            const subdomains = ['map01', 'map02', 'map03', 'map04'];
+            const subdomain = subdomains[(x + y) % subdomains.length];
+            return `https://${subdomain}.eniro.com/geowebcache/service/tms1.0.0/nautical/${z}/${x}/${y}.png`;
+        },
+        tileGrid: ol.tilegrid.createXYZ({ maxZoom: 17 }),
+        attributions: '&copy; <a href="https://kartor.eniro.se/">Eniro</a> / Kort & Matrikelstyrelsen',
+        maxZoom: 17
+    })
+}));
+
 
 addOverlayLayer("OpenSeaMap", new ol.layer.Tile({
     source: new ol.source.XYZ({


### PR DESCRIPTION
There are sea charts for Scandinavia available online from Skippo (previously Eniro). See https://www.skippo.se/plan for an example

This PR adds Eniro/Skippo charts as an optional map type to the AIS Catcher web GUI. It will make it a little nicer to track AIS traffic navigating around obstacles etc. 

Covered region:
<img width="1720" alt="image" src="https://github.com/user-attachments/assets/8b038cab-7804-4606-a4e2-02f9b26dd3d5" />

Zoomed in:
<img width="1720" alt="image" src="https://github.com/user-attachments/assets/a866d2fb-7d39-4f77-ab89-c879917a02fa" />
