### PR TITLE
fix build with musl (Alpine/PostmarketOS)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,12 @@ endif()
 # Debug symbols and optimization settings for AIS-catcher
 if(UNIX AND NOT APPLE)
     find_library(DL_LIBRARY dl REQUIRED)
+    check_include_file("execinfo.h" HASEXECINFO)
+
+    if(HASEXECINFO)
+        add_definitions(-DHASEXECINFO)
+    endif()
+
     if(ENABLE_DEBUG)
         add_compile_options(
             -g3

--- a/Device/Serial.cpp
+++ b/Device/Serial.cpp
@@ -16,6 +16,9 @@
 */
 
 #include <cstring>
+#ifndef _WIN32
+#include <sys/select.h>
+#endif
 
 #include "Serial.h"
 

--- a/Device/UDP.cpp
+++ b/Device/UDP.cpp
@@ -16,6 +16,9 @@
 */
 
 #include <cstring>
+#ifndef _WIN32
+#include <sys/select.h>
+#endif
 
 #include "Utilities.h"
 #include "UDP.h"

--- a/Library/StackTracer.cpp
+++ b/Library/StackTracer.cpp
@@ -1,4 +1,5 @@
 #if defined(__linux__) || defined(__linux) || defined(linux)
+#ifdef HASEXECINFO
 
 #include <execinfo.h>
 #include <csignal>
@@ -140,4 +141,5 @@ namespace debugging {
 
 }
 
+#endif
 #endif


### PR DESCRIPTION
sys/select.h is apparently not included indirectly here, so include it directly. Since the definitions are only used locally in a method, do not pollute the namespace unnecessarily and include it in the .cpp
execinfo.h is not available, so rather add a check for it.