### PR TITLE
Fix hidden virtual method warnings in MapTiles

### DIFF
--- a/Application/MapTiles.h
+++ b/Application/MapTiles.h
@@ -51,7 +51,7 @@ public:
         return tileData;
     };
 
-    virtual std::string generatePluginCode(bool overlay) { return ""; };
+    virtual std::string generatePluginCode(bool overlay) const = 0;
 
     std::string getName() const { return name; }
     std::string getAttribution() const { return attribution; }
@@ -213,7 +213,7 @@ public:
         return tileData;
     }
 
-    virtual std::string generatePluginCode(bool overlay) const
+    virtual std::string generatePluginCode(bool overlay) const override
     {
         if (!db)
             return "";
@@ -519,7 +519,7 @@ public:
         return tileData;
     }
 
-    std::string generatePluginCode(bool overlay) override
+    std::string generatePluginCode(bool overlay) const override
     {
         std::stringstream ss;
 


### PR DESCRIPTION
This PR resolves compiler warnings related to a hidden virtual method:

```
AIS-catcher/Application/MapTiles.h:54:25: warning: ‘virtual std::string MapTiles::generatePluginCode(bool)’ was hidden [-Woverloaded-virtual=]
   54 |     virtual std::string generatePluginCode(bool overlay) { return ""; };
      |                         ^~~~~~~~~~~~~~~~~~
AIS-catcher/Application/MapTiles.h:216:25: note:   by ‘virtual std::string MBTilesSupport::generatePluginCode(bool) const’
  216 |     virtual std::string generatePluginCode(bool overlay) const
      |                         ^~~~~~~~~~~~~~~~~~
```

**Notes**
* No functional changes intended - just cleanup for clearer, warning-free builds.