### PR TITLE
Source/Device/SoapySDR.cpp: added explicit longest timeoutUs to avoid initial stop

### DIFF
--- a/Source/Device/SoapySDR.cpp
+++ b/Source/Device/SoapySDR.cpp
@@ -100,13 +100,14 @@ namespace Device {
 		std::vector<CFLOAT32> input(BUFFER_SIZE);
 		void* buffers[] = { input.data() };
 		long long timeNs = 0;
+		const long timeout_us = 1000000;
 		int flags = 0;
 
 		try {
 			dev->activateStream(stream);
 
 			while (isStreaming()) {
-				int ret = dev->readStream(stream, buffers, BUFFER_SIZE, flags, timeNs);
+				int ret = dev->readStream(stream, buffers, BUFFER_SIZE, flags, timeNs, timeout_us);
 
 				if (ret < 0) {
 					Error()  << "SOAPYSDR: error reading stream: " << SoapySDR_errToStr(ret) << std::endl;


### PR DESCRIPTION
Depending on the low-level **_SoapySDR_** driver’s implementation and buffering policy, a certain number of samples may be internally collected and kept in reserve to mitigate issues caused by operating system scheduling fluctuations.

With the default `timeoutUS` value of `100000` (100 ms), the first `readStream` call may return zero samples, especially at lower sample rates. This condition is currently treated as an error, causing **AIS-catcher** to halt.

Other tools using a _**SoapySDR**_ source typically configure `timeoutUS` to 500 ms or 1 s to ensure sufficient buffering. By increasing the timeout, the first `readStream` call reliably receives enough samples to build an internal reserve and return the requested number of samples.

This change aligns the behavior with common practice and prevents premature termination during stream initialization.

Tested with [LiteX-M2SDR](https://github.com/enjoy-digital/litex_m2sdr)