### PR TITLE
Fix the broken build when there is no openssl.

### DIFF
--- a/Source/IO/Protocol.h
+++ b/Source/IO/Protocol.h
@@ -400,6 +400,8 @@ namespace Protocol
 			Error() << "TLS: OpenSSL support not available. Cannot connect.";
 			return false;
 		}
+
+		void setStats(IO::OutputStats *s) {}
 	};
 #endif
 


### PR DESCRIPTION
This change fixes the broken build which was introduced in https://github.com/jvde-github/AIS-catcher/commit/aca418706e46c39e76fe47a480c47750b472b757