### PR TITLE
Update Makefile for OS X

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ CFLAGS_SOAPYSDR = -DHASSOAPYSDR
 CFLAGS_ZLIB = -DHASZLIB ${shell pkg-config --cflags zlib}
 CFLAGS_PSQL  = -DHASPSQL ${shell pkg-config --cflags libpq}
 
-LFLAGS_RTL = $(shell pkg-config --libs-only-l librtlsdr)
+LFLAGS_RTL = $(shell pkg-config --libs librtlsdr)
 LFLAGS_AIRSPYHF = $(shell pkg-config --libs libairspyhf)
 LFLAGS_AIRSPY = $(shell pkg-config --libs libairspy)
 LFLAGS_SDRPLAY = -lsdrplay_api


### PR DESCRIPTION
Makefile:23 had pkg-config --libs-only-l librtlsdr instead of pkg-config --libs librtlsdr. The --libs-only-l flag strips the -L path flags, so the linker only received -lrtlsdr without knowing where to find the library. On Homebrew (macOS), libraries live in non-standard paths like /opt/homebrew/Cellar/... so the -L flag is required. All other libraries in the Makefile correctly used --libs.