### PR TITLE
Support free-threaded Python wheels for aiscat

### DIFF
--- a/Source/Marine/Message.cpp
+++ b/Source/Marine/Message.cpp
@@ -24,7 +24,18 @@
 namespace AIS
 {
 
-	int Message::ID = 0;
+	std::atomic<int> Message::ID{0};
+
+	int Message::nextSeqId()
+	{
+		int current = ID.load(std::memory_order_relaxed);
+		for (;;)
+		{
+			int next = (current + 1) % 10;
+			if (ID.compare_exchange_weak(current, next, std::memory_order_relaxed))
+				return current;
+		}
+	}
 
 	static int NMEAchecksum(const std::string &s)
 	{
@@ -184,13 +195,22 @@ namespace AIS
 
 	int Message::getNMEATagBlock(std::string &out, const char *suffix) const
 	{
-		static int groupId = 0;
+		static std::atomic<int> groupId{0};
 
 		int total = sentences().size();
 		int seq = 1;
 
+		int group = 0;
 		if (total > 1)
-			groupId = (groupId % 9999) + 1;
+		{
+			int current = groupId.load(std::memory_order_relaxed);
+			for (;;)
+			{
+				group = (current % 9999) + 1;
+				if (groupId.compare_exchange_weak(current, group, std::memory_order_relaxed))
+					break;
+			}
+		}
 
 		JSON::Writer w(out);
 
@@ -235,7 +255,7 @@ namespace AIS
 				w.append('-');
 				w.append_int((long long)total);
 				w.append('-');
-				w.append_int((long long)groupId);
+				w.append_int((long long)group);
 			}
 
 			// Calculate checksum over tag block content (between backslashes).
@@ -548,7 +568,7 @@ namespace AIS
 		const int IDX_NUMBER = 9;
 
 		if (id >= 0 && id < 10)
-			ID = id;
+			ID.store(id, std::memory_order_relaxed);
 
 		int nAISletters = (length + 6 - 1) / 6;
 		int nSentences = (nAISletters == 0) ? 1 : (nAISletters + MAX_NMEA_CHARS - 1) / MAX_NMEA_CHARS;
@@ -562,9 +582,7 @@ namespace AIS
 		static constexpr char hex[] = "0123456789ABCDEF";
 		const char own = own_mmsi == mmsi() ? 'O' : 'M';
 		const char count = (char)(nSentences + '0');
-		const char seq = (nSentences > 1) ? (char)(ID + '0') : 0;
-		if (nSentences > 1)
-			ID = (ID + 1) % 10;
+		const char seq = (nSentences > 1) ? (char)(nextSeqId() + '0') : 0;
 
 		for (int s = 0, l = 0; s < nSentences; s++)
 		{

--- a/Source/Marine/Message.h
+++ b/Source/Marine/Message.h
@@ -19,6 +19,7 @@
 
 #include <string>
 #include <time.h>
+#include <atomic>
 #include <chrono>
 #include <cstdint>
 #include <vector>
@@ -59,7 +60,8 @@ namespace AIS
 	{
 	protected:
 		const int MAX_NMEA_CHARS = 56;
-		static int ID;
+		static std::atomic<int> ID;
+		static int nextSeqId();
 
 		uint8_t data[MAX_AIS_BYTES + 4]; // +4 padding so 5-byte reads in getText/getUint never go out of bounds
 		int64_t rxtime; // microseconds since epoch

--- a/python/README.md
+++ b/python/README.md
@@ -114,6 +114,18 @@ Each decoded message carries two timestamps:
 
 The queue is unbounded — drain it after each feed, or memory grows.
 
+### Free-threaded Python and thread safety
+
+aiscat supports free-threaded CPython builds. Independent `Decoder` instances
+can be used from different Python threads, which lets no-GIL Python decode in
+parallel.
+
+A single `Decoder` instance is stateful and is not safe for concurrent method
+calls. Do not call `feed()`, `next()`, or `pending()` on the same `Decoder` from
+multiple threads at the same time. Create one `Decoder` per worker thread
+instead. Also avoid mutating a `bytearray` in another thread while passing it to
+`feed()`.
+
 ```python
 # Manual streaming pattern (for total control)
 import aiscat

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -36,9 +36,9 @@ sdist.include = [
 ]
 
 [tool.cibuildwheel]
-build = "cp39-* cp310-* cp311-* cp312-* cp313-* cp314-*"
+build = "cp39-* cp310-* cp311-* cp312-* cp313-* cp314-* cp314t-*"
 skip = "*-win32 *-manylinux_i686 *-musllinux_i686 pp*"
-test-command = "python {project}/python/tests/test_decode.py"
+test-command = "python {project}/python/tests/test_decode.py && python {project}/python/tests/test_free_threading.py"
 
 [tool.cibuildwheel.linux]
 archs = ["auto64"]

--- a/python/src/aiscat/_core.cpp
+++ b/python/src/aiscat/_core.cpp
@@ -345,9 +345,11 @@ static PyObject *Decoder_pending(DecoderObject *self, PyObject *Py_UNUSED(ignore
 
 static PyMethodDef Decoder_methods[] = {
     {"feed", (PyCFunction)Decoder_feed, METH_O,
-     "Feed bytes/bytearray/str to the decoder. Returns number of pending messages."},
+     "Feed bytes/bytearray/str to the decoder. Returns number of pending messages. "
+     "Do not call concurrently on the same Decoder."},
     {"next", (PyCFunction)Decoder_next, METH_NOARGS,
-     "Pop the next decoded message as a dict, or None if the queue is empty."},
+     "Pop the next decoded message as a dict, or None if the queue is empty. "
+     "Do not call concurrently on the same Decoder."},
     {"pending", (PyCFunction)Decoder_pending, METH_NOARGS,
      "Number of decoded messages waiting in the queue."},
     {nullptr, nullptr, 0, nullptr}
@@ -379,6 +381,10 @@ PyMODINIT_FUNC PyInit__core(void) {
 
     PyObject *m = PyModule_Create(&coremodule);
     if (!m) return nullptr;
+
+#ifdef Py_GIL_DISABLED
+    PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED);
+#endif
 
     g_keys = (PyObject **)PyMem_Calloc((size_t)AIS::KEY_COUNT, sizeof(PyObject *));
     if (!g_keys) { Py_DECREF(m); return nullptr; }

--- a/python/tests/test_free_threading.py
+++ b/python/tests/test_free_threading.py
@@ -1,0 +1,130 @@
+import concurrent.futures
+import json
+import os
+import subprocess
+import sys
+import sysconfig
+import textwrap
+
+import aiscat
+
+
+SAMPLE_A = b"!AIVDM,1,1,,A,15MgK45P3@G?fl0E`JbR0OwT0@MS,0*4E\r\n"
+SAMPLE_B = b"!AIVDM,1,1,,B,177KQJ5000G?tO`K>RA1wUbN0TKH,0*5C\r\n"
+SAMPLE_TYPE5 = (
+    b"!AIVDM,2,1,4,A,55O0W7`00001L@gCWGA2uItLth@DqtL5@F22220j1h742t0Ht0000000,0*08\r\n"
+    b"!AIVDM,2,2,4,A,000000000000000,2*20\r\n"
+)
+
+
+def test_import_does_not_enable_gil():
+    if not sysconfig.get_config_var("Py_GIL_DISABLED"):
+        return
+
+    code = """
+import sys
+import aiscat
+assert not sys._is_gil_enabled()
+"""
+    env = os.environ.copy()
+    env.pop("PYTHON_GIL", None)
+    subprocess.run([sys.executable, "-c", textwrap.dedent(code)], check=True, env=env)
+
+
+def test_independent_decoders_from_multiple_threads():
+    if sysconfig.get_config_var("Py_GIL_DISABLED"):
+        assert not sys._is_gil_enabled()
+
+    def worker(iterations):
+        dec = aiscat.Decoder()
+        count = 0
+        for i in range(iterations):
+            dec.feed(SAMPLE_A if i % 2 == 0 else SAMPLE_B)
+            while True:
+                msg = dec.next()
+                if msg is None:
+                    break
+                assert msg["type"] == 1
+                count += 1
+        return count
+
+    iterations = 1000
+    workers = 4
+    with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
+        counts = list(executor.map(worker, [iterations] * workers))
+
+    assert counts == [iterations] * workers
+
+
+def test_multifragment_decoders_from_multiple_threads():
+    def worker(iterations):
+        dec = aiscat.Decoder()
+        count = 0
+        for _ in range(iterations):
+            dec.feed(SAMPLE_TYPE5)
+            msg = dec.next()
+            assert msg is not None
+            assert msg["type"] == 5
+            assert dec.next() is None
+            count += 1
+        return count
+
+    iterations = 250
+    workers = 4
+    with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
+        counts = list(executor.map(worker, [iterations] * workers))
+
+    assert counts == [iterations] * workers
+
+
+def test_json_decoders_from_multiple_threads():
+    def worker(iterations):
+        dec = aiscat.Decoder(format="json")
+        count = 0
+        for _ in range(iterations):
+            dec.feed(SAMPLE_A)
+            msg = dec.next()
+            assert msg is not None
+            assert json.loads(msg)["type"] == 1
+            assert dec.next() is None
+            count += 1
+        return count
+
+    iterations = 250
+    workers = 4
+    with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
+        counts = list(executor.map(worker, [iterations] * workers))
+
+    assert counts == [iterations] * workers
+
+
+def test_nmea_tag_decoders_from_multiple_threads():
+    def worker(iterations):
+        dec = aiscat.Decoder(format="nmea_tag")
+        count = 0
+        for _ in range(iterations):
+            dec.feed(SAMPLE_TYPE5)
+            msg = dec.next()
+            assert msg is not None
+            assert msg.count(b"!AIVDM") == 2
+            assert b"g:1-2-" in msg
+            assert b"g:2-2-" in msg
+            assert dec.next() is None
+            count += 1
+        return count
+
+    iterations = 250
+    workers = 4
+    with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
+        counts = list(executor.map(worker, [iterations] * workers))
+
+    assert counts == [iterations] * workers
+
+
+if __name__ == "__main__":
+    test_import_does_not_enable_gil()
+    test_independent_decoders_from_multiple_threads()
+    test_multifragment_decoders_from_multiple_threads()
+    test_json_decoders_from_multiple_threads()
+    test_nmea_tag_decoders_from_multiple_threads()
+    print("OK")


### PR DESCRIPTION
## Summary
- declare the aiscat CPython extension as free-threading compatible on Py_GIL_DISABLED builds
- make shared multi-fragment NMEA/tag counters atomic so independent Decoder instances can run concurrently
- add cp314t wheel coverage, free-threading smoke tests, and README/docstring thread-safety notes

## Threading contract
Independent Decoder instances may be used from different Python threads. A single Decoder remains stateful and should not receive concurrent feed/next/pending calls.

## Validation
- python3 -m py_compile python/tests/test_free_threading.py
- git diff --check
- typos
- built and tested cp314t wheel on Python 3.14.6 free-threaded: default import keeps gil_enabled False with zero warnings
- ran python/tests/test_decode.py and python/tests/test_free_threading.py on cp314t, cp314, and cp313 wheels
- built CLI with make CC=g++ -j$(nproc) using -std=c++11 and ran ./AIS-catcher -l