### PR TITLE
Prioritize selected ship label

### DIFF
--- a/frontend/src/script.js
+++ b/frontend/src/script.js
@@ -784,7 +784,13 @@ const labelStyle = function (feature) {
         }));
     }
 
-    return new ol.style.Style({ text: text });
+    const isSelected = ('ship' in feature && feature.ship.mmsi == card_mmsi) ||
+                       ('plane' in feature && getICAO(feature.plane) == card_mmsi);
+
+    return new ol.style.Style({
+        text: text,
+        zIndex: isSelected ? 1000 : 0
+    });
 };
 
 const hoverCircleStyleFunction = function (feature) {
@@ -949,7 +955,18 @@ const rangeLayer = new ol.layer.Vector({
 const labelLayer = new ol.layer.Vector({
     source: labelVector,
     style: labelStyle,
-    declutter: settings.labels_declutter || true
+    declutter: settings.labels_declutter || true,
+    renderOrder: function(a, b) {
+        const aSelected = ('ship' in a && a.ship.mmsi == card_mmsi) || ('plane' in a && getICAO(a.plane) == card_mmsi);
+        const bSelected = ('ship' in b && b.ship.mmsi == card_mmsi) || ('plane' in b && getICAO(b.plane) == card_mmsi);
+        if (aSelected && !bSelected) {
+            return -1;
+        }
+        if (!aSelected && bSelected) {
+            return 1;
+        }
+        return 0;
+    }
 });
 
 
@@ -4499,6 +4516,7 @@ function showShipcard(type, m, pixel = undefined) {
     }
 
     trackLayer.changed();
+    labelLayer.changed();
     updateFocusMarker();
 }
 


### PR DESCRIPTION
# Description

### Context
In high-density traffic zones, OpenLayers' automatic decluttering pass (`declutter: true`) can hide the label of the currently selected/active vessel to avoid overlapping nearby labels. In kiosk mode (or during normal selection), this leads to a suboptimal user experience where the active vessel's name isn't clear on the map.  Specifically, when there is a cluster of ships and you click on one or the kiosk mode rotation selects one. 

### Changes
This PR ensures the selected vessel's label is always guaranteed visibility and draws on top of neighboring labels. 

* **Custom `renderOrder` on `labelLayer`:**
  Added a `renderOrder` comparator to the label vector layer. It places the currently selected vessel (`card_mmsi`) at the front of the array during rendering. This guarantees that OpenLayers processes the selected vessel's label first in its declutter pass, securing its placement before layout constraints hide others.
* **Dynamic `zIndex` in Label Style:**
  Modified the label style function to assign a higher `zIndex` (`1000` vs `0`) to the active ship or plane label. This ensures that even if it overlaps with others, it draws above them.
* **Immediate Layer Refreshes:**
  Added `labelLayer.changed()` alongside `trackLayer.changed()` when the active ship selection changes. This forces OpenLayers to redraw labels.