### PR TITLE
Kiosk Mode: Preserve ship card expanded state during auto-rotation

### DIFF
--- a/frontend/src/script.js
+++ b/frontend/src/script.js
@@ -4488,7 +4488,7 @@ function showShipcard(type, m, pixel = undefined) {
         }
 
 
-        if (isShipcardMax()) {
+        if (isShipcardMax() && !settings.kiosk) {
             toggleShipcardSize();
         }
         if (!visible) shipcardMinIfMaxonMobile();


### PR DESCRIPTION
Prevents the ship card from automatically collapsing when the UI auto-rotates to a new vessel in kiosk mode. 

I don't think we wanted to intentionally collapse it when in kiosk mode. 