### PR TITLE
Fix maximum-length AIS Message 26 handling

### DIFF
--- a/Source/Marine/AIS.h
+++ b/Source/Marine/AIS.h
@@ -41,7 +41,7 @@ namespace AIS
 		int station = 0;
 		int own_mmsi = -1;
 
-		const int MaxBits = MAX_AIS_LENGTH;
+		const int MaxBits = MAX_AIS_FRAME_LENGTH;
 		const int MIN_TRAINING_BITS = 4;
 
 		bool QuickReset = true;

--- a/Source/Marine/Message.cpp
+++ b/Source/Marine/Message.cpp
@@ -397,6 +397,8 @@ namespace AIS
 	{
 		if (getLength() == 0)
 			return true;
+		if (getLength() > MAX_AIS_LENGTH)
+			return false;
 
 		const int ml[28] = {149, 149, 149, 168, 418, 88, 72, 56, 168, 70, 168, 72, 40, 40, 88, 92, 80, 168, 312, 70, 271, 145, 154, 160, 72, 60, 96, 168};
 
@@ -701,8 +703,8 @@ namespace AIS
 		int byteIdx = (pos * 6) >> 3;
 		int endBits = (pos + count) * 6;
 
-		if (endBits > MAX_AIS_LENGTH)
-			count = (MAX_AIS_LENGTH - pos * 6) / 6;
+		if (endBits > MAX_AIS_NMEA_LENGTH)
+			count = (MAX_AIS_NMEA_LENGTH - pos * 6) / 6;
 
 		if (count < 0)
 			return;

--- a/Source/Marine/Message.h
+++ b/Source/Marine/Message.h
@@ -35,8 +35,11 @@
 namespace AIS
 {
 
-#define MAX_AIS_BYTES 128
-#define MAX_AIS_LENGTH (MAX_AIS_BYTES * 8)
+#define MAX_AIS_LENGTH 1064
+#define MAX_AIS_BYTES ((MAX_AIS_LENGTH + 7) / 8)
+#define MAX_AIS_NMEA_LENGTH (((MAX_AIS_LENGTH + 5) / 6) * 6)
+#define MAX_AIS_FRAME_LENGTH (MAX_AIS_LENGTH + 16 + 7)
+#define MAX_AIS_FRAME_BYTES ((MAX_AIS_FRAME_LENGTH + 7) / 8)
 
 	class GPS
 	{
@@ -63,7 +66,7 @@ namespace AIS
 		static std::atomic<int> ID;
 		static int nextSeqId();
 
-		uint8_t data[MAX_AIS_BYTES + 4]; // +4 padding so 5-byte reads in getText/getUint never go out of bounds
+		uint8_t data[MAX_AIS_FRAME_BYTES + 4]; // Includes FCS/closing-flag capture and read padding.
 		int64_t rxtime; // microseconds since epoch
 		int64_t toa; // time of arrival in seconds since epoch
 		int length;
@@ -191,7 +194,7 @@ namespace AIS
 		}
 
 		// Raw payload bytes; for hot decoders that bulk-load multiple fields.
-		// Buffer is MAX_AIS_BYTES + 4 bytes (zero-padded by clear()).
+		// Buffer has four zero-padded bytes after the raw-frame capture area.
 		const uint8_t* raw() const { return data; }
 
 		unsigned getUint(int start, int len) const
@@ -253,7 +256,7 @@ namespace AIS
 
 		void setBit(int i, bool b)
 		{
-			if (i >= MAX_AIS_LENGTH || i < 0)
+			if (i >= MAX_AIS_FRAME_LENGTH || i < 0)
 				return;
 
 			if (b)
@@ -264,7 +267,7 @@ namespace AIS
 
 		bool getBit(int i) const
 		{
-			if (i >= MAX_AIS_LENGTH || i < 0)
+			if (i >= MAX_AIS_FRAME_LENGTH || i < 0)
 				return false;
 
 			return data[i >> 3] & (1 << (i & 7));

--- a/python/tests/test_decode.py
+++ b/python/tests/test_decode.py
@@ -15,6 +15,27 @@ SAMPLE_TYPE5 = (
     b"!AIVDM,2,1,4,A,55O0W7`00001L@gCWGA2uItLth@DqtL5@F22220j1h742t0Ht0000000,0*08\r\n"
     b"!AIVDM,2,2,4,A,000000000000000,2*20\r\n"
 )
+SAMPLE_TYPE26_MAX = (
+    b"!AIVDM,4,1,7,A,J1mg=5AEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE,0*69\r\n"
+    b"!AIVDM,4,2,7,A,EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE,0*17\r\n"
+    b"!AIVDM,4,3,7,A,EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE,0*16\r\n"
+    b"!AIVDM,4,4,7,A,EEEEE@4SA@,4*76\r\n"
+)
+# The same 1068 armored bits with zero fill bits declared; checksum adjusted.
+SAMPLE_TYPE26_TOO_LONG = SAMPLE_TYPE26_MAX.replace(b",4*76\r\n", b",0*72\r\n")
+
+
+def unescape_binary_packet(packet):
+    decoded = bytearray()
+    index = 0
+    while index < len(packet):
+        value = packet[index]
+        if value == 0xAD:
+            index += 1
+            value = {0xAD: 0xAD, 0xAE: 0x0A, 0xAF: 0x0D}[packet[index]]
+        decoded.append(value)
+        index += 1
+    return bytes(decoded)
 
 
 def test_decode_type1():
@@ -45,6 +66,33 @@ def test_decode_two_sentences():
     print(f"decoded {len(msgs)} messages")
     for m in msgs:
         print(" ", m)
+
+
+def test_decode_max_length_type26():
+    dec = aiscat.Decoder()
+    assert dec.feed(SAMPLE_TYPE26_MAX) == 1
+    msg = dec.next()
+    assert msg is not None
+    assert msg["type"] == 26
+    assert msg["mmsi"] == 123456789
+    assert msg["radio"] == 0x12345
+
+    binary_dec = aiscat.Decoder(format="binary")
+    assert binary_dec.feed(SAMPLE_TYPE26_MAX) == 1
+    encoded_packet = binary_dec.next()
+    packet = unescape_binary_packet(encoded_packet)
+    assert packet[:2] == b"\xac\x00"
+    assert int.from_bytes(packet[12:14], "big") == 1064
+
+    binary_roundtrip = aiscat.Decoder()
+    assert binary_roundtrip.feed(encoded_packet) == 1
+    roundtrip_msg = binary_roundtrip.next()
+    assert roundtrip_msg["type"] == 26
+    assert roundtrip_msg["radio"] == 0x12345
+
+    oversized_dec = aiscat.Decoder()
+    assert oversized_dec.feed(SAMPLE_TYPE26_TOO_LONG) == 0
+    assert oversized_dec.next() is None
 
 
 # Free-threading: independent Decoder instances must be usable from different
@@ -158,6 +206,7 @@ def test_nmea_tag_decoders_from_multiple_threads():
 if __name__ == "__main__":
     test_decode_type1()
     test_decode_two_sentences()
+    test_decode_max_length_type26()
     test_import_does_not_enable_gil()
     test_independent_decoders_from_multiple_threads()
     test_multifragment_decoders_from_multiple_threads()


### PR DESCRIPTION
## Summary

- raise the AIS protocol-message limit to the 1064-bit Message 26 maximum from
  ITU-R M.1371-6 Table 81
- preserve the complete six-bit-armored NMEA payload until fill bits are removed
- give the raw decoder separate capacity for the message, 16-bit FCS, and the
  closing-flag bits consumed during detection
- reject a final decoded message that remains longer than 1064 bits
- add maximum-length multipart NMEA and binary round-trip regression coverage

Fixes #594.

## Validation

- Before the fix, the 1064-bit fixture was reported as 1016 bits.
- After the fix, it is reported as 1064 bits and its trailing communication
  state is decoded as `0x12345`.
- A binary packet generated from the fixture decodes back to the same Message
  26 and communication state.
- The same armored payload with zero fill bits (1068 final bits) is rejected.
- Existing `python/tests/test_decode.py` tests pass.
- A complete AIS-catcher C++ Release build links and `AIS-catcher -h` runs.
- `git diff --check` and `typos` pass for all changed files.
