### PR TITLE
Build Python 3.15 wheels for aiscat

### DIFF
--- a/.github/workflows/aiscat-release.yml
+++ b/.github/workflows/aiscat-release.yml
@@ -36,7 +36,7 @@ jobs:
           platforms: ${{ matrix.qemu }}
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.4.1
+        uses: pypa/cibuildwheel@v4.2.0
         env:
           CIBW_ARCHS: ${{ matrix.archs }}
         with:

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -36,8 +36,8 @@ sdist.include = [
 ]
 
 [tool.cibuildwheel]
-build = "cp39-* cp310-* cp311-* cp312-* cp313-* cp314-* cp314t-*"
-skip = "*-win32 *-manylinux_i686 *-musllinux_i686 pp*"
+build = "cp39-* cp310-* cp311-* cp312-* cp313-* cp314-* cp314t-* cp315-* cp315t-*"
+skip = "*-win32 *-manylinux_i686 *-musllinux_i686"
 test-command = "python {project}/python/tests/test_decode.py"
 
 [tool.cibuildwheel.linux]


### PR DESCRIPTION
## Summary

- build regular CPython 3.15 wheels for `aiscat`
- build free-threaded CPython 3.15 wheels for `aiscat`
- update cibuildwheel to v4.2.0, where CPython 3.15 RC1 is a default,
  final-ABI-compatible target
- remove the obsolete PyPy skip selector reported by cibuildwheel 4

This keeps the existing version-specific extension implementation unchanged.
ABI3T support is intentionally out of scope.

PyPy has never been part of the explicit build selector, and `aiscat` has not
published PyPy wheels. Removing the redundant `pp*` skip therefore does not
drop existing support or add PyPy builds. PyPy compatibility and wheel support
should be evaluated separately.

## Validation

- built and tested `cp315`/`cp315t` wheels across the existing Linux, macOS,
  and Windows release matrix, including x86_64/AMD64, armv7l, aarch64, and
  ARM64 ([run](https://github.com/honglei/AIS-catcher/actions/runs/31879826475))
- produced all 18 expected `cp315`/`cp315t` wheel artifacts
- verified the cleaned cibuildwheel 4 configuration without warnings
  ([run](https://github.com/honglei/AIS-catcher/actions/runs/31880242237))
- built and tested every configured CPython selector from `cp39` through
  `cp315t` on Linux x86_64, for both manylinux and musllinux
  ([run](https://github.com/honglei/AIS-catcher/actions/runs/31880570790))
- did not upload artifacts to TestPyPI or PyPI
